### PR TITLE
#19 Make ExecuteAsync protected

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Post Coverage Comment
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           path: coverage_report/SummaryGithub.md
 

--- a/src/DannyGoodacre.Cqrs.Testing/DannyGoodacre.Cqrs.Testing.csproj
+++ b/src/DannyGoodacre.Cqrs.Testing/DannyGoodacre.Cqrs.Testing.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <PackageId>DannyGoodacre.Cqrs.Testing</PackageId>
-        <Version>0.6.0</Version>
+        <Version>0.7.0</Version>
         <Authors>Danny Goodacre</Authors>
         <Description>Testing abstractions and base classes for verifying implementations of DannyGoodacre.Cqrs.</Description>
         <RepositoryUrl>https://github.com/dannygoodacre/DannyGoodacre.Core</RepositoryUrl>

--- a/src/DannyGoodacre.Cqrs/CommandHandlerBase.cs
+++ b/src/DannyGoodacre.Cqrs/CommandHandlerBase.cs
@@ -45,7 +45,7 @@ public abstract partial class CommandHandlerBase<TCommand, TResult>
     /// <param name="command">The command to validate and process.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while performing the operation.</param>
     /// <returns>A <see cref="Result"/> indicating the outcome of the operation.</returns>
-    public async virtual Task<TResult> ExecuteAsync(TCommand command, CancellationToken cancellationToken = default)
+    protected async virtual Task<TResult> ExecuteAsync(TCommand command, CancellationToken cancellationToken = default)
     {
         var validationState = new ValidationState();
 

--- a/src/DannyGoodacre.Cqrs/DannyGoodacre.Cqrs.csproj
+++ b/src/DannyGoodacre.Cqrs/DannyGoodacre.Cqrs.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <PackageId>DannyGoodacre.Cqrs</PackageId>
-        <Version>0.6.0</Version>
+        <Version>0.7.0</Version>
         <Authors>Danny Goodacre</Authors>
         <Description>A lightweight CQRS and clean architecture foundation library including state and transaction control.</Description>
         <RepositoryUrl>https://github.com/dannygoodacre/DannyGoodacre.Core</RepositoryUrl>

--- a/src/DannyGoodacre.Cqrs/QueryHandler.cs
+++ b/src/DannyGoodacre.Cqrs/QueryHandler.cs
@@ -38,7 +38,7 @@ public abstract partial class QueryHandler<TQuery, TResult>(ILogger logger)
     /// <param name="query">The query to validate and process.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while performing the operation.</param>
     /// <returns>A <see cref="Result{T}"/> indicating the outcome of the operation.</returns>
-    public async Task<Result<TResult>> ExecuteAsync(TQuery query, CancellationToken cancellationToken = default)
+    protected async Task<Result<TResult>> ExecuteAsync(TQuery query, CancellationToken cancellationToken = default)
     {
         var validationState = new ValidationState();
 

--- a/src/DannyGoodacre.Cqrs/StateCommandHandlerBase.cs
+++ b/src/DannyGoodacre.Cqrs/StateCommandHandlerBase.cs
@@ -15,7 +15,7 @@ public abstract partial class StateCommandHandlerBase<TCommand, TResult>
 
     private IStateUnit StateUnit { get; }
 
-    public async override Task<TResult> ExecuteAsync(TCommand command, CancellationToken cancellationToken = default)
+    protected async override Task<TResult> ExecuteAsync(TCommand command, CancellationToken cancellationToken = default)
     {
         try
         {

--- a/src/DannyGoodacre.Cqrs/TransactionCommandHandlerBase.cs
+++ b/src/DannyGoodacre.Cqrs/TransactionCommandHandlerBase.cs
@@ -34,7 +34,7 @@ public abstract partial class TransactionCommandHandlerBase<TCommand, TResult>
     /// </remarks>
     protected virtual int ExpectedChanges { get; set; } = -1;
 
-    public async override Task<TResult> ExecuteAsync(TCommand command, CancellationToken cancellationToken = default)
+    protected async override Task<TResult> ExecuteAsync(TCommand command, CancellationToken cancellationToken = default)
     {
         await using ITransaction transaction = await TransactionUnit.BeginTransactionAsync(cancellationToken);
 

--- a/src/DannyGoodacre.Primitives/DannyGoodacre.Primitives.csproj
+++ b/src/DannyGoodacre.Primitives/DannyGoodacre.Primitives.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <PackageId>DannyGoodacre.Primitives</PackageId>
-        <Version>0.6.0</Version>
+        <Version>0.7.0</Version>
         <Authors>Danny Goodacre</Authors>
         <Description>A lightweight primitives library providing Result types and a structured validation state for method responses.</Description>
         <RepositoryUrl>https://github.com/dannygoodacre/DannyGoodacre.Core</RepositoryUrl>

--- a/src/DannyGoodacre.Testing/DannyGoodacre.Testing.csproj
+++ b/src/DannyGoodacre.Testing/DannyGoodacre.Testing.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <PackageId>DannyGoodacre.Testing</PackageId>
-        <Version>0.6.0</Version>
+        <Version>0.7.0</Version>
         <Authors>Danny Goodacre</Authors>
         <Description>A lightweight testing foundation library.</Description>
         <RepositoryUrl>https://github.com/dannygoodacre/DannyGoodacre.Core</RepositoryUrl>

--- a/tests/DannyGoodacre.Cqrs.Tests/CommandHandlerTests.cs
+++ b/tests/DannyGoodacre.Cqrs.Tests/CommandHandlerTests.cs
@@ -19,6 +19,9 @@ public sealed class CommandHandlerTests : CommandHandlerTestBase<CommandHandlerT
 
         protected override Task<Result> InternalExecuteAsync(TestCommand command, CancellationToken cancellationToken = default)
             => _testInternalExecuteAsync(command, cancellationToken);
+
+        public Task<Result> TestExecuteAsync(TestCommand command, CancellationToken cancellationToken)
+            => ExecuteAsync(command, cancellationToken);
     }
 
     private const string TestName = "Test Command Handler";
@@ -31,7 +34,7 @@ public sealed class CommandHandlerTests : CommandHandlerTestBase<CommandHandlerT
 
     protected override string CommandName => TestName;
 
-    protected override Task<Result> Act() => CommandHandler.ExecuteAsync(_testCommand, TestCancellationToken);
+    protected override Task<Result> Act() => CommandHandler.TestExecuteAsync(_testCommand, TestCancellationToken);
 
     [SetUp]
     public void SetUp()

--- a/tests/DannyGoodacre.Cqrs.Tests/QueryHandlerTests.cs
+++ b/tests/DannyGoodacre.Cqrs.Tests/QueryHandlerTests.cs
@@ -17,8 +17,11 @@ public class QueryHandlerTests : QueryHandlerTestBase<QueryHandlerTests.TestQuer
         protected override void Validate(ValidationState validationState, TestQuery query)
             => _testValidate(validationState, query);
 
-        protected override Task<Result<int>> InternalExecuteAsync(TestQuery query, CancellationToken cancellationToken)
+        protected override Task<Result<int>> InternalExecuteAsync(TestQuery query, CancellationToken cancellationToken = default)
             => _testInternalExecuteAsync(query, cancellationToken);
+
+        public Task<Result<int>> TestExecuteAsync(TestQuery query, CancellationToken cancellationToken = default)
+            => ExecuteAsync(query, cancellationToken);
     }
 
     private const string TestName = "Test Query Handler";
@@ -33,7 +36,7 @@ public class QueryHandlerTests : QueryHandlerTestBase<QueryHandlerTests.TestQuer
 
     protected override string QueryName => TestName;
 
-    protected override Task<Result<int>> Act() => QueryHandler.ExecuteAsync(_testQuery, CancellationToken);
+    protected override Task<Result<int>> Act() => QueryHandler.TestExecuteAsync(_testQuery, CancellationToken);
 
     [SetUp]
     public void SetUp()

--- a/tests/DannyGoodacre.Cqrs.Tests/StateCommandHandlerTests.cs
+++ b/tests/DannyGoodacre.Cqrs.Tests/StateCommandHandlerTests.cs
@@ -21,7 +21,7 @@ public sealed class StateCommandHandlerTests : StateCommandHandlerTestBase<State
         protected override Task<Result> InternalExecuteAsync(TestCommand command, CancellationToken cancellationToken = default)
             => _testInternalExecuteAsync(command, cancellationToken);
 
-        public new Task<Result> TestExecuteAsync(TestCommand command, CancellationToken cancellationToken = default)
+        public Task<Result> TestExecuteAsync(TestCommand command, CancellationToken cancellationToken = default)
             => ExecuteAsync(command, cancellationToken);
     }
 

--- a/tests/DannyGoodacre.Cqrs.Tests/StateCommandHandlerTests.cs
+++ b/tests/DannyGoodacre.Cqrs.Tests/StateCommandHandlerTests.cs
@@ -20,6 +20,9 @@ public sealed class StateCommandHandlerTests : StateCommandHandlerTestBase<State
 
         protected override Task<Result> InternalExecuteAsync(TestCommand command, CancellationToken cancellationToken = default)
             => _testInternalExecuteAsync(command, cancellationToken);
+
+        public new Task<Result> TestExecuteAsync(TestCommand command, CancellationToken cancellationToken = default)
+            => ExecuteAsync(command, cancellationToken);
     }
 
     private const string TestName = "Test State Command Handler";
@@ -32,7 +35,7 @@ public sealed class StateCommandHandlerTests : StateCommandHandlerTestBase<State
 
     protected override string CommandName => TestName;
 
-    protected override Task<Result> Act() => CommandHandler.ExecuteAsync(_testCommand, TestCancellationToken);
+    protected override Task<Result> Act() => CommandHandler.TestExecuteAsync(_testCommand, TestCancellationToken);
 
     [SetUp]
     public void SetUp()

--- a/tests/DannyGoodacre.Cqrs.Tests/StateCommandHandlerWithReturnValueTests.cs
+++ b/tests/DannyGoodacre.Cqrs.Tests/StateCommandHandlerWithReturnValueTests.cs
@@ -20,6 +20,9 @@ public sealed class StateCommandHandlerWithReturnValueTests : StateCommandHandle
 
         protected override Task<Result<int>> InternalExecuteAsync(TestCommand command, CancellationToken cancellationToken = default)
             => _testInternalExecuteAsync(command, cancellationToken);
+
+        public Task<Result<int>> TestExecuteAsync(TestCommand command, CancellationToken cancellationToken = default)
+            => ExecuteAsync(command, cancellationToken);
     }
 
     private const string TestName = "Test State Command Handler";
@@ -34,7 +37,7 @@ public sealed class StateCommandHandlerWithReturnValueTests : StateCommandHandle
 
     protected override string CommandName => TestName;
 
-    protected override Task<Result<int>> Act() => CommandHandler.ExecuteAsync(_testCommand, TestCancellationToken);
+    protected override Task<Result<int>> Act() => CommandHandler.TestExecuteAsync(_testCommand, TestCancellationToken);
 
     [SetUp]
     public void SetUp()

--- a/tests/DannyGoodacre.Cqrs.Tests/TransactionCommandHandlerTests.cs
+++ b/tests/DannyGoodacre.Cqrs.Tests/TransactionCommandHandlerTests.cs
@@ -20,6 +20,9 @@ public sealed class TransactionCommandHandlerTests : TransactionCommandHandlerTe
 
         protected override Task<Result> InternalExecuteAsync(TestCommand command, CancellationToken cancellationToken = default)
             => _internalExecuteAsync(command, cancellationToken);
+
+        public Task<Result> TestExecuteAsync(TestCommand command, CancellationToken cancellationToken = default)
+            => ExecuteAsync(command, cancellationToken);
     }
 
     private const string TestName = "Test Transaction Command Handler";
@@ -34,7 +37,7 @@ public sealed class TransactionCommandHandlerTests : TransactionCommandHandlerTe
 
     protected override string CommandName => TestName;
 
-    protected override Task<Result> Act() => CommandHandler.ExecuteAsync(_testCommand, TestCancellationToken);
+    protected override Task<Result> Act() => CommandHandler.TestExecuteAsync(_testCommand, TestCancellationToken);
 
     protected override int TestActualChanges => _testActualChanges;
 

--- a/tests/DannyGoodacre.Cqrs.Tests/TransactionCommandHandlerWithReturnValueTests.cs
+++ b/tests/DannyGoodacre.Cqrs.Tests/TransactionCommandHandlerWithReturnValueTests.cs
@@ -20,6 +20,9 @@ public sealed class TransactionCommandHandlerWithReturnValueTests : TransactionC
 
         protected override Task<Result<int>> InternalExecuteAsync(TestCommand command, CancellationToken cancellationToken = default)
             => _internalExecuteAsync(command, cancellationToken);
+
+        public Task<Result<int>> TestExecuteAsync(TestCommand command, CancellationToken cancellationToken = default)
+            => ExecuteAsync(command, cancellationToken);
     }
 
     private const string TestName = "Test Transaction Command Handler";
@@ -36,7 +39,7 @@ public sealed class TransactionCommandHandlerWithReturnValueTests : TransactionC
 
     protected override string CommandName => TestName;
 
-    protected override Task<Result<int>> Act() => CommandHandler.ExecuteAsync(_testCommand, TestCancellationToken);
+    protected override Task<Result<int>> Act() => CommandHandler.TestExecuteAsync(_testCommand, TestCancellationToken);
 
     protected override int TestActualChanges => _testActualChanges;
 


### PR DESCRIPTION
Make `ExecuteAsync` protected to enforce defining an entry point explicitly in a handler.