### PR TITLE
#25 Add properties comparer to AssertSuccess, add TestBase tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,8 +43,7 @@ jobs:
           reportgenerator \
             -reports:./coverage_data/*/coverage.cobertura.xml \
             -targetdir:coverage_report \
-            -reporttypes:"Html;MarkdownSummaryGithub" \
-            -assemblyfilters:"-DannyGoodacre.Testing;-DannyGoodacre.Cqrs.Testing"
+            -reporttypes:"Html;MarkdownSummaryGithub"
 
       - name: Add Artifact Link to Summary File
         run: |

--- a/DannyGoodacre.Core.slnx
+++ b/DannyGoodacre.Core.slnx
@@ -8,5 +8,6 @@
     <Folder Name="/tests/">
         <Project Path="./tests/DannyGoodacre.Primitives.Tests/DannyGoodacre.Primitives.Tests.csproj" />
         <Project Path="./tests/DannyGoodacre.Cqrs.Tests/DannyGoodacre.Cqrs.Tests.csproj" />
+        <Project Path="tests/DannyGoodacre.Testing.Tests/DannyGoodacre.Testing.Tests.csproj" />
     </Folder>
 </Solution>

--- a/src/DannyGoodacre.Cqrs.Testing/DannyGoodacre.Cqrs.Testing.csproj
+++ b/src/DannyGoodacre.Cqrs.Testing/DannyGoodacre.Cqrs.Testing.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <PackageId>DannyGoodacre.Cqrs.Testing</PackageId>
-        <Version>0.8.0</Version>
+        <Version>0.8.1</Version>
         <Authors>Danny Goodacre</Authors>
         <Description>Testing abstractions and base classes for verifying implementations of DannyGoodacre.Cqrs.</Description>
         <RepositoryUrl>https://github.com/dannygoodacre/DannyGoodacre.Core</RepositoryUrl>
@@ -18,10 +18,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.5.1" />
+        <PackageReference Include="NUnit" Version="4.6.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/DannyGoodacre.Cqrs/DannyGoodacre.Cqrs.csproj
+++ b/src/DannyGoodacre.Cqrs/DannyGoodacre.Cqrs.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <PackageId>DannyGoodacre.Cqrs</PackageId>
-        <Version>0.8.0</Version>
+        <Version>0.8.1</Version>
         <Authors>Danny Goodacre</Authors>
         <Description>A lightweight CQRS and clean architecture foundation library including state and transaction control.</Description>
         <RepositoryUrl>https://github.com/dannygoodacre/DannyGoodacre.Core</RepositoryUrl>
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/DannyGoodacre.Primitives/DannyGoodacre.Primitives.csproj
+++ b/src/DannyGoodacre.Primitives/DannyGoodacre.Primitives.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <PackageId>DannyGoodacre.Primitives</PackageId>
-        <Version>0.8.0</Version>
+        <Version>0.8.1</Version>
         <Authors>Danny Goodacre</Authors>
         <Description>A lightweight primitives library providing Result types and a structured validation state for method responses.</Description>
         <RepositoryUrl>https://github.com/dannygoodacre/DannyGoodacre.Core</RepositoryUrl>

--- a/src/DannyGoodacre.Testing/DannyGoodacre.Testing.csproj
+++ b/src/DannyGoodacre.Testing/DannyGoodacre.Testing.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <PackageId>DannyGoodacre.Testing</PackageId>
-        <Version>0.8.0</Version>
+        <Version>0.8.1</Version>
         <Authors>Danny Goodacre</Authors>
         <Description>A lightweight testing foundation library.</Description>
         <RepositoryUrl>https://github.com/dannygoodacre/DannyGoodacre.Core</RepositoryUrl>
@@ -18,9 +18,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.5.1" />
+        <PackageReference Include="NUnit" Version="4.6.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/DannyGoodacre.Testing/TestBase.cs
+++ b/src/DannyGoodacre.Testing/TestBase.cs
@@ -119,7 +119,7 @@ public abstract class TestBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.IsSuccess, Is.False);
-            Assert.That(result.Status, Is.EqualTo(Status.Invalid));
+            Assert.That(result.Status, Is.EqualTo(Status.NotFound));
         }
     }
 

--- a/src/DannyGoodacre.Testing/TestBase.cs
+++ b/src/DannyGoodacre.Testing/TestBase.cs
@@ -86,18 +86,6 @@ public abstract class TestBase
         }
     }
 
-    protected static void AssertInternalError(Result result)
-    {
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.IsSuccess, Is.False);
-
-            Assert.That(result.Status, Is.EqualTo(Status.InternalError));
-
-            Assert.That(result.Error, Is.Null);
-        }
-    }
-
     protected static void AssertInternalError(Result result, string error)
     {
         using (Assert.EnterMultipleScope())

--- a/src/DannyGoodacre.Testing/TestBase.cs
+++ b/src/DannyGoodacre.Testing/TestBase.cs
@@ -34,7 +34,7 @@ public abstract class TestBase
         {
             Assert.That(result.IsSuccess, Is.True);
             Assert.That(result.Status, Is.EqualTo(Status.Success));
-            Assert.That(result.Value, Is.EqualTo(expectedValue));
+            Assert.That(result.Value, Is.EqualTo(expectedValue).UsingPropertiesComparer());
         }
     }
 

--- a/src/DannyGoodacre.Testing/TestBase.cs
+++ b/src/DannyGoodacre.Testing/TestBase.cs
@@ -15,15 +15,7 @@ public abstract class TestBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.IsSuccess, Is.True);
-            Assert.That(result.Status, Is.EqualTo(Status.Success));
-        }
-    }
 
-    protected static void AssertSuccess<T>(Result<T> result)
-    {
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.IsSuccess, Is.True);
             Assert.That(result.Status, Is.EqualTo(Status.Success));
         }
     }
@@ -33,7 +25,9 @@ public abstract class TestBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.IsSuccess, Is.True);
+
             Assert.That(result.Status, Is.EqualTo(Status.Success));
+
             Assert.That(result.Value, Is.EqualTo(expectedValue).UsingPropertiesComparer());
         }
     }
@@ -43,15 +37,7 @@ public abstract class TestBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.IsSuccess, Is.False);
-            Assert.That(result.Status, Is.EqualTo(Status.Invalid));
-        }
-    }
 
-    protected static void AssertInvalid<T>(Result<T> result)
-    {
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.IsSuccess, Is.False);
             Assert.That(result.Status, Is.EqualTo(Status.Invalid));
         }
     }
@@ -61,17 +47,9 @@ public abstract class TestBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.IsSuccess, Is.False);
-            Assert.That(result.Status, Is.EqualTo(Status.DomainError));
-            Assert.That(result.Error, Is.EqualTo(error));
-        }
-    }
 
-    protected static void AssertDomainError<T>(Result<T> result, string error)
-    {
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.IsSuccess, Is.False);
             Assert.That(result.Status, Is.EqualTo(Status.DomainError));
+
             Assert.That(result.Error, Is.EqualTo(error));
         }
     }
@@ -81,17 +59,9 @@ public abstract class TestBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.IsSuccess, Is.False);
-            Assert.That(result.Status, Is.EqualTo(Status.Conflict));
-            Assert.That(result.Error, Is.EqualTo(error));
-        }
-    }
 
-    protected static void AssertConflict<T>(Result<T> result, string error)
-    {
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.IsSuccess, Is.False);
             Assert.That(result.Status, Is.EqualTo(Status.Conflict));
+
             Assert.That(result.Error, Is.EqualTo(error));
         }
     }
@@ -101,15 +71,7 @@ public abstract class TestBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.IsSuccess, Is.False);
-            Assert.That(result.Status, Is.EqualTo(Status.Canceled));
-        }
-    }
 
-    protected static void AssertCanceled<T>(Result<T> result)
-    {
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.IsSuccess, Is.False);
             Assert.That(result.Status, Is.EqualTo(Status.Canceled));
         }
     }
@@ -119,16 +81,20 @@ public abstract class TestBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.IsSuccess, Is.False);
+
             Assert.That(result.Status, Is.EqualTo(Status.NotFound));
         }
     }
 
-    protected static void AssertNotFound<T>(Result<T> result)
+    protected static void AssertInternalError(Result result)
     {
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.IsSuccess, Is.False);
-            Assert.That(result.Status, Is.EqualTo(Status.NotFound));
+
+            Assert.That(result.Status, Is.EqualTo(Status.InternalError));
+
+            Assert.That(result.Error, Is.Null);
         }
     }
 
@@ -137,18 +103,22 @@ public abstract class TestBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.IsSuccess, Is.False);
+
             Assert.That(result.Status, Is.EqualTo(Status.InternalError));
+
             Assert.That(result.Error, Is.EqualTo(error));
         }
     }
 
-    protected static void AssertInternalError<T>(Result<T> result, string error)
+    protected static void AssertInternalError(Result result, Exception exception)
     {
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.IsSuccess, Is.False);
+
             Assert.That(result.Status, Is.EqualTo(Status.InternalError));
-            Assert.That(result.Error, Is.EqualTo(error));
+
+            Assert.That(result.Exception, Is.EqualTo(exception));
         }
     }
 

--- a/tests/DannyGoodacre.Cqrs.Tests/DannyGoodacre.Cqrs.Tests.csproj
+++ b/tests/DannyGoodacre.Cqrs.Tests/DannyGoodacre.Cqrs.Tests.csproj
@@ -7,14 +7,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.5.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
+        <PackageReference Include="NUnit" Version="4.6.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/DannyGoodacre.Primitives.Tests/DannyGoodacre.Primitives.Tests.csproj
+++ b/tests/DannyGoodacre.Primitives.Tests/DannyGoodacre.Primitives.Tests.csproj
@@ -7,13 +7,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="NUnit" Version="4.5.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+        <PackageReference Include="NUnit" Version="4.6.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/DannyGoodacre.Primitives.Tests/ResultTests.cs
+++ b/tests/DannyGoodacre.Primitives.Tests/ResultTests.cs
@@ -7,40 +7,55 @@ namespace DannyGoodacre.Primitives.Tests;
 public sealed class ResultTests : TestBase
 {
     [Test]
-    public void IsSuccess_WhenSuccessful_ReturnsTrue()
+    public void IsSuccess_WhenSuccessful_ShouldReturnTrue()
     {
+        // Arrange
+        Result result = Result.Success();
+
         // Act
-        var result = Result.Success();
+        bool isSuccess = result.IsSuccess;
 
         // Assert
-        Assert.That(result.IsSuccess, Is.True);
+        Assert.That(isSuccess, Is.True);
     }
 
     [Test]
-    public void IsSuccess_WhenUnsuccessful_ReturnsFalse()
+    public void IsSuccess_WhenUnsuccessful_ShouldReturnFalse()
     {
         // Act
-        var result = Result.InternalError("Test Error");
+        Result result = Result.InternalError("Test Error Message");
+
+        // Act
+        bool isSuccess = result.IsSuccess;
 
         // Assert
-        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(isSuccess, Is.False);
     }
 
     [Test]
     public void Success()
     {
         // Act
-        var result = Result.Success();
+        Result result = Result.Success();
 
         // Assert
-        Assert.That(result.Status, Is.EqualTo(Status.Success));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Status, Is.EqualTo(Status.Success));
+
+            Assert.That(result.Error, Is.Null);
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.Null);
+        }
     }
 
     [Test]
     public void Invalid()
     {
         // Arrange
-        var validationState = new ValidationState();
+        ValidationState validationState = new ValidationState();
 
         const string property1 = "Test Property 1";
         const string property2 = "Test Property 2";
@@ -52,14 +67,18 @@ public sealed class ResultTests : TestBase
         validationState.AddError(property2, error2);
 
         // Act
-        var result = Result.Invalid(validationState);
+        Result result = Result.Invalid(validationState);
 
         // Assert
         using (Assert.EnterMultipleScope())
         {
-
             Assert.That(result.Status, Is.EqualTo(Status.Invalid));
-            Assert.That(result.ValidationState, Is.EqualTo(validationState));
+
+            Assert.That(result.Error, Is.Null);
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.EqualTo(validationState).UsingPropertiesComparer());
         }
     }
 
@@ -67,16 +86,21 @@ public sealed class ResultTests : TestBase
     public void DomainError()
     {
         // Arrange
-        const string message = "Test Message";
+        const string message = "Test Error Message";
 
         // Act
-        var result = Result.DomainError(message);
+        Result result = Result.DomainError(message);
 
         // Assert
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Status, Is.EqualTo(Status.DomainError));
+
             Assert.That(result.Error, Is.EqualTo(message));
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.Null);
         }
     }
 
@@ -84,16 +108,21 @@ public sealed class ResultTests : TestBase
     public void Conflict()
     {
         // Arrange
-        const string message = "Test Message";
+        const string message = "Test Conflict Message";
 
         // Act
-        var result = Result.Conflict(message);
+        Result result = Result.Conflict(message);
 
         // Assert
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Status, Is.EqualTo(Status.Conflict));
+
             Assert.That(result.Error, Is.EqualTo(message));
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.Null);
         }
     }
 
@@ -101,81 +130,104 @@ public sealed class ResultTests : TestBase
     public void Canceled()
     {
         // Act
-        var result = Result.Canceled();
+        Result result = Result.Canceled();
 
         // Assert
-        Assert.That(result.Status, Is.EqualTo(Status.Canceled));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Status, Is.EqualTo(Status.Canceled));
+
+            Assert.That(result.Error, Is.Null);
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.Null);
+        }
     }
 
     [Test]
     public void NotFound()
     {
         // Act
-        var result = Result.NotFound();
-
-        // Assert
-        Assert.That(result.Status, Is.EqualTo(Status.NotFound));
-    }
-
-    [Test]
-    public void InternalError()
-    {
-        // Act
-        var result = Result.InternalError("Test Error");
-
-        // Assert
-        Assert.That(result.Status, Is.EqualTo(Status.InternalError));
-    }
-
-    [Test]
-    public void InternalErrorWithMessage()
-    {
-        // Arrange
-        const string message = "Test Message";
-
-        // Act
-        var result = Result.InternalError(message);
+        Result result = Result.NotFound();
 
         // Assert
         using (Assert.EnterMultipleScope())
         {
+            Assert.That(result.Status, Is.EqualTo(Status.NotFound));
 
+            Assert.That(result.Error, Is.Null);
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.Null);
+        }
+    }
+
+    [Test]
+    public void InternalError_WithMessage()
+    {
+        // Act
+        const string message = "Test Error Message";
+
+        Result result = Result.InternalError(message);
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
             Assert.That(result.Status, Is.EqualTo(Status.InternalError));
+
             Assert.That(result.Error, Is.EqualTo(message));
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.Null);
         }
     }
 
     [Test]
-    public void InternalErrorWithException()
+    public void InternalError_WithException()
     {
         // Arrange
-        var exception = new Exception("Test Exception");
+        Exception exception = new Exception("Test Exception");
 
         // Act
-        var result = Result.InternalError(exception);
+        Result result = Result.InternalError(exception);
 
         // Assert
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Status, Is.EqualTo(Status.InternalError));
-            Assert.That(result.Exception, Is.EqualTo(exception));
+
+            Assert.That(result.Error, Is.Null);
+
+            Assert.That(result.Exception, Is.EqualTo(exception).UsingPropertiesComparer());
+
+            Assert.That(result.ValidationState, Is.Null);
         }
     }
 
     [Test]
-    public void ImplicitSuccess()
+    public void Success_WithImplicitValue()
     {
         // Arrange
         const int value = 123;
 
         // Act
-        var result = Result.Success(value);
+        Result<int> result = Result.Success(value);
 
         // Assert
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Status, Is.EqualTo(Status.Success));
+
             Assert.That(result.Value, Is.EqualTo(value));
+
+            Assert.That(result.Error, Is.Null);
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.Null);
         }
     }
 }

--- a/tests/DannyGoodacre.Primitives.Tests/ResultWithValueTests.cs
+++ b/tests/DannyGoodacre.Primitives.Tests/ResultWithValueTests.cs
@@ -6,23 +6,31 @@ namespace DannyGoodacre.Primitives.Tests;
 public sealed class ResultWithValueTests
 {
     [Test]
-    public void IsSuccess_WhenSuccessful_ReturnsTrue()
+    public void IsSuccess_WhenSuccessful_ShouldReturnTrue()
     {
+        // Arrange
+        const int value = 123;
+
+        Result<int> result = Result<int>.Success(value);
+
         // Act
-        var result = Result<int>.Success(123);
+        bool isSuccess = result.IsSuccess;
 
         // Assert
-        Assert.That(result.IsSuccess, Is.True);
+        Assert.That(isSuccess, Is.True);
     }
 
     [Test]
-    public void IsSuccess_WhenUnsuccessful_ReturnsFalse()
+    public void IsSuccess_WhenUnsuccessful_ShouldReturnFalse()
     {
+        // Arrange
+        Result<int> result = Result<int>.InternalError("Test Error Message");
+
         // Act
-        var result = Result<int>.InternalError("Test Error");
+        bool isSuccess = result.IsSuccess;
 
         // Assert
-        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(isSuccess, Is.False);
     }
 
     [Test]
@@ -32,13 +40,20 @@ public sealed class ResultWithValueTests
         const int value = 123;
 
         // Act
-        var result = Result<int>.Success(value);
+        Result<int> result = Result<int>.Success(value);
 
         // Assert
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Status, Is.EqualTo(Status.Success));
+
             Assert.That(result.Value, Is.EqualTo(value));
+
+            Assert.That(result.Error, Is.Null);
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.Null);
         }
     }
 
@@ -46,7 +61,7 @@ public sealed class ResultWithValueTests
     public void Invalid()
     {
         // Arrange
-        var validationState = new ValidationState();
+        ValidationState validationState = new ValidationState();
 
         const string property1 = "Test Property 1";
         const string property2 = "Test Property 2";
@@ -58,13 +73,20 @@ public sealed class ResultWithValueTests
         validationState.AddError(property2, error2);
 
         // Act
-        var result = Result<int>.Invalid(validationState);
+        Result<int> result = Result<int>.Invalid(validationState);
 
         // Assert
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Status, Is.EqualTo(Status.Invalid));
-            Assert.That(result.ValidationState, Is.EqualTo(validationState));
+
+            Assert.That(result.Value, Is.Default);
+
+            Assert.That(result.Error, Is.Null);
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.EqualTo(validationState).UsingPropertiesComparer());
         }
     }
 
@@ -75,13 +97,20 @@ public sealed class ResultWithValueTests
         const string message = "Test Message";
 
         // Act
-        var result = Result<int>.DomainError(message);
+        Result<int> result = Result<int>.DomainError(message);
 
         // Assert
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Status, Is.EqualTo(Status.DomainError));
+
+            Assert.That(result.Value, Is.Default);
+
             Assert.That(result.Error, Is.EqualTo(message));
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.Null);
         }
     }
 
@@ -92,13 +121,20 @@ public sealed class ResultWithValueTests
         const string message = "Test Message";
 
         // Act
-        var result = Result<int>.Conflict(message);
+        Result<int> result = Result<int>.Conflict(message);
 
         // Assert
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Status, Is.EqualTo(Status.Conflict));
+
+            Assert.That(result.Value, Is.Default);
+
             Assert.That(result.Error, Is.EqualTo(message));
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.Null);
         }
     }
 
@@ -106,63 +142,89 @@ public sealed class ResultWithValueTests
     public void Canceled()
     {
         // Act
-        var result = Result<int>.Canceled();
+        Result<int> result = Result<int>.Canceled();
 
         // Assert
-        Assert.That(result.Status, Is.EqualTo(Status.Canceled));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Status, Is.EqualTo(Status.Canceled));
+
+            Assert.That(result.Value, Is.Default);
+
+            Assert.That(result.Error, Is.Null);
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.Null);
+        }
     }
 
     [Test]
     public void NotFound()
     {
         // Act
-        var result = Result<int>.NotFound();
-
-        // Assert
-        Assert.That(result.Status, Is.EqualTo(Status.NotFound));
-    }
-
-    [Test]
-    public void InternalError()
-    {
-        // Act
-        var result = Result<int>.InternalError("Test Error");
-
-        // Assert
-        Assert.That(result.Status, Is.EqualTo(Status.InternalError));
-    }
-
-    [Test]
-    public void InternalErrorWithMessage()
-    {
-        // Arrange
-        const string message = "Test Message";
-
-        // Act
-        var result = Result<int>.InternalError(message);
+        Result<int> result = Result<int>.NotFound();
 
         // Assert
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(result.Status, Is.EqualTo(Status.InternalError));
-            Assert.That(result.Error, Is.EqualTo(message));
+            Assert.That(result.Status, Is.EqualTo(Status.NotFound));
+
+            Assert.That(result.Value, Is.Default);
+
+            Assert.That(result.Error, Is.Null);
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.Null);
         }
     }
 
     [Test]
-    public void InternalErrorWithException()
+    public void InternalError_WithMessage()
     {
         // Arrange
-        var exception = new Exception("Test Exception");
+        const string message = "Test Error Message";
 
         // Act
-        var result = Result<int>.InternalError(exception);
+        Result<int> result = Result<int>.InternalError(message);
 
         // Assert
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Status, Is.EqualTo(Status.InternalError));
-            Assert.That(result.Exception, Is.EqualTo(exception));
+
+            Assert.That(result.Value, Is.Default);
+
+            Assert.That(result.Error, Is.EqualTo(message));
+
+            Assert.That(result.Exception, Is.Null);
+
+            Assert.That(result.ValidationState, Is.Null);
+        }
+    }
+
+    [Test]
+    public void InternalError_WithException()
+    {
+        // Arrange
+        Exception exception = new("Test Exception");
+
+        // Act
+        Result<int> result = Result<int>.InternalError(exception);
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Status, Is.EqualTo(Status.InternalError));
+
+            Assert.That(result.Value, Is.Default);
+
+            Assert.That(result.Error, Is.Null);
+
+            Assert.That(result.Exception, Is.EqualTo(exception).UsingPropertiesComparer());
+
+            Assert.That(result.ValidationState, Is.Null);
         }
     }
 }

--- a/tests/DannyGoodacre.Testing.Tests/DannyGoodacre.Testing.Tests.csproj
+++ b/tests/DannyGoodacre.Testing.Tests/DannyGoodacre.Testing.Tests.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\src\DannyGoodacre.Testing\DannyGoodacre.Testing.csproj" />
+        <ProjectReference Include="..\..\src\DannyGoodacre.Testing\DannyGoodacre.Testing.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/DannyGoodacre.Testing.Tests/DannyGoodacre.Testing.Tests.csproj
+++ b/tests/DannyGoodacre.Testing.Tests/DannyGoodacre.Testing.Tests.csproj
@@ -7,9 +7,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-      <PackageReference Include="NUnit" Version="4.6.1" />
-      <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+        <PackageReference Include="NUnit" Version="4.6.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/DannyGoodacre.Testing.Tests/DannyGoodacre.Testing.Tests.csproj
+++ b/tests/DannyGoodacre.Testing.Tests/DannyGoodacre.Testing.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+      <PackageReference Include="NUnit" Version="4.6.1" />
+      <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\DannyGoodacre.Testing\DannyGoodacre.Testing.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/DannyGoodacre.Testing.Tests/TestBaseTests.cs
+++ b/tests/DannyGoodacre.Testing.Tests/TestBaseTests.cs
@@ -256,7 +256,7 @@ public sealed class TestBaseTests
     }
 
     [Test]
-    public void AssertInternalError_WhenInternalError_DoesNotThrow()
+    public void AssertInternalError_WhenInternalErrorWithMessage_DoesNotThrow()
     {
         // Arrange
         const string message = "Test Error Message";
@@ -268,7 +268,7 @@ public sealed class TestBaseTests
     }
 
     [Test]
-    public void AssertInternalError_WhenInternalErrorAndMessagesDoNotMatch_DoesThrow()
+    public void AssertInternalError_WhenInternalErrorWithMessagesAndMessagesDoNotMatch_DoesThrow()
     {
         // Arrange
         const string expectedMessage = "Test Expected Message";
@@ -291,5 +291,31 @@ public sealed class TestBaseTests
 
         // Act & Assert
         Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertInternalError(result, message));
+    }
+
+    [Test]
+    public void AssertInternalError_WhenInternalErrorWithException_ShouldNotThrowException()
+    {
+        // Arrange
+        Exception exception = new("Test Exception");
+
+        Result result = Result.InternalError(exception);
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => TestBase.TestAssertInternalError(result, exception));
+    }
+
+    [Test]
+    public void AssertInternalError_WhenInternalErrorWithExceptionAndExceptionsDoNotMatch_ShouldNotThrowException()
+    {
+        // Arrange
+        Exception expectedException = new("Test Expected Exception");
+
+        Exception actualException = new("Test Actual Exception");
+
+        Result result = Result.InternalError(actualException);
+
+        // Act & Assert
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertInternalError(result, expectedException));
     }
 }

--- a/tests/DannyGoodacre.Testing.Tests/TestBaseTests.cs
+++ b/tests/DannyGoodacre.Testing.Tests/TestBaseTests.cs
@@ -1,0 +1,73 @@
+using DannyGoodacre.Primitives;
+using NUnit.Framework;
+
+namespace DannyGoodacre.Testing.Tests;
+
+[TestFixture]
+public sealed class TestBaseTests
+{
+    private sealed record TestModel(int Id, string Name, List<string> Items);
+
+    private sealed class TestWrapper : TestBase
+    {
+        public static void TestAssertSuccess<T>(Result<T> result, T expectedValue)
+            => AssertSuccess(result, expectedValue);
+    }
+
+    [Test]
+    public void AssertSuccess_WhenSuccessfulAndValuesMatch_ShouldNotThrowAssertionException()
+    {
+        // Arrange
+        TestModel expected = new(123, "Test Name", ["Test Item 1", "Test Item 2"]);
+
+        TestModel actual = new(123, "Test Name", ["Test Item 1", "Test Item 2"]);
+
+        Result<TestModel> result = Result<TestModel>.Success(actual);
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => TestWrapper.TestAssertSuccess(result, expected));
+    }
+
+    [Test]
+    public void AssertSuccess_WhenNotSuccessful_ShouldThrowAssertionException()
+    {
+        // Arrange
+        TestModel expected = new TestModel(1, "Test", ["A"]);
+
+        Result<TestModel> result = Result<TestModel>.InternalError("Test Error Message");
+
+        // Act & Assert
+        MultipleAssertException? exception = Assert.Throws<MultipleAssertException>(()
+            => TestWrapper.TestAssertSuccess(result, expected));
+    }
+
+    [Test]
+    public void AssertSuccess_WhenPropertiesMismatch_ShouldThrowAssertionException()
+    {
+        // Arrange
+        TestModel expected = new TestModel(1, "Test Expected Name", ["Test Item 1"]);
+
+        TestModel actual = new TestModel(1, "Test Actual Name", ["Test Item 1"]);
+
+        Result<TestModel> result = Result<TestModel>.Success(actual);
+
+        // Act & Assert
+        MultipleAssertException? exception = Assert.Throws<MultipleAssertException>(()
+            => TestWrapper.TestAssertSuccess(result, expected));
+    }
+
+    [Test]
+    public void AssertSuccess_WhenNestedPropertiesMismatch_ShouldThrowAssertionException()
+    {
+        // Arrange
+        TestModel expected = new TestModel(1, "Test Name", ["Test Expected Item 1"]);
+
+        TestModel actual = new TestModel(1, "Test Name", ["Test Actual Item 1"]);
+
+        Result<TestModel> result = Result<TestModel>.Success(actual);
+
+        // Act & Assert
+        MultipleAssertException? exception = Assert.Throws<MultipleAssertException>(()
+            => TestWrapper.TestAssertSuccess(result, expected));
+    }
+}

--- a/tests/DannyGoodacre.Testing.Tests/TestBaseTests.cs
+++ b/tests/DannyGoodacre.Testing.Tests/TestBaseTests.cs
@@ -8,14 +8,59 @@ public sealed class TestBaseTests
 {
     private sealed record TestModel(int Id, string Name, List<string> Items);
 
-    private sealed class TestWrapper : TestBase
+    private sealed class TestBase : Testing.TestBase
     {
-        public static void TestAssertSuccess<T>(Result<T> result, T expectedValue)
-            => AssertSuccess(result, expectedValue);
+        public static void TestAssertSuccess(Result result) => AssertSuccess(result);
+
+        public static void TestAssertSuccess<T>(Result<T> result, T expectedValue) => AssertSuccess(result, expectedValue);
+
+        public static void TestAssertInvalid(Result result) => AssertInvalid(result);
+
+        public static void TestAssertDomainError(Result result, string error) => AssertDomainError(result, error);
+
+        public static void TestAssertConflict(Result result, string error) => AssertConflict(result, error);
+
+        public static void TestAssertCanceled(Result result) => AssertCanceled(result);
+
+        public static void TestAssertNotFound(Result result) => AssertNotFound(result);
+
+        public static void TestAssertInternalError(Result result, string error) => AssertInternalError(result, error);
+
+        public static void TestAssertInternalError(Result result, Exception exception) => AssertInternalError(result, exception);
     }
 
     [Test]
-    public void AssertSuccess_WhenSuccessfulAndValuesMatch_ShouldNotThrowAssertionException()
+    public void AssertSuccess_WhenSuccess_DoesNotThrow()
+    {
+        // Arrange
+        Result result = Result.Success();
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => TestBase.TestAssertSuccess(result));
+    }
+
+    [Test]
+    public void AssertSuccess_WhenNotSuccess_DoesThrow()
+    {
+        // Arrange
+        Result result = Result.InternalError("Test Error Message");
+
+        // Act & Assert
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertSuccess(result));
+    }
+
+    [Test]
+    public void AssertSuccess_WithValue_WhenSuccess_DoesNotThrow()
+    {
+        // Arrange
+        Result<int> result = Result<int>.Success(123);
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => TestBase.TestAssertSuccess(result));
+    }
+
+    [Test]
+    public void AssertSuccess_WithValue_WhenSuccessAndValuesMatch_DoesNotThrow()
     {
         // Arrange
         TestModel expected = new(123, "Test Name", ["Test Item 1", "Test Item 2"]);
@@ -25,49 +70,226 @@ public sealed class TestBaseTests
         Result<TestModel> result = Result<TestModel>.Success(actual);
 
         // Act & Assert
-        Assert.DoesNotThrow(() => TestWrapper.TestAssertSuccess(result, expected));
+        Assert.DoesNotThrow(() => TestBase.TestAssertSuccess(result, expected));
     }
 
     [Test]
-    public void AssertSuccess_WhenNotSuccessful_ShouldThrowAssertionException()
+    public void AssertSuccess_WithValue_WhenNotSuccess_DoesThrow()
     {
         // Arrange
-        TestModel expected = new TestModel(1, "Test", ["A"]);
+        Result<int> result = Result<int>.InternalError("Test Error Message");
+
+        // Act & Assert
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertSuccess(result));
+    }
+
+    [Test]
+    public void AssertSuccess_WithValue_WhenNotSuccessAndExpectedValueProvided_DoesThrow()
+    {
+        // Arrange
+        TestModel expected = new(1, "Test", ["A"]);
 
         Result<TestModel> result = Result<TestModel>.InternalError("Test Error Message");
 
         // Act & Assert
-        MultipleAssertException? exception = Assert.Throws<MultipleAssertException>(()
-            => TestWrapper.TestAssertSuccess(result, expected));
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertSuccess(result, expected));
     }
 
     [Test]
-    public void AssertSuccess_WhenPropertiesMismatch_ShouldThrowAssertionException()
+    public void AssertSuccess_WithValue_WhenSuccessAndValuesDoNotMatch_DoesThrow()
     {
         // Arrange
-        TestModel expected = new TestModel(1, "Test Expected Name", ["Test Item 1"]);
+        TestModel expected = new(1, "Test Expected Name", ["Test Item 1"]);
 
-        TestModel actual = new TestModel(1, "Test Actual Name", ["Test Item 1"]);
+        TestModel actual = new(1, "Test Actual Name", ["Test Item 1"]);
 
         Result<TestModel> result = Result<TestModel>.Success(actual);
 
         // Act & Assert
-        MultipleAssertException? exception = Assert.Throws<MultipleAssertException>(()
-            => TestWrapper.TestAssertSuccess(result, expected));
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertSuccess(result, expected));
     }
 
     [Test]
-    public void AssertSuccess_WhenNestedPropertiesMismatch_ShouldThrowAssertionException()
+    public void AssertSuccess_WithValue_WhenSuccessAndNestedPropertiesDoNotMatch_DoesThrow()
     {
         // Arrange
-        TestModel expected = new TestModel(1, "Test Name", ["Test Expected Item 1"]);
+        TestModel expected = new(1, "Test Name", ["Test Expected Item 1"]);
 
-        TestModel actual = new TestModel(1, "Test Name", ["Test Actual Item 1"]);
+        TestModel actual = new(1, "Test Name", ["Test Actual Item 1"]);
 
         Result<TestModel> result = Result<TestModel>.Success(actual);
 
         // Act & Assert
-        MultipleAssertException? exception = Assert.Throws<MultipleAssertException>(()
-            => TestWrapper.TestAssertSuccess(result, expected));
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertSuccess(result, expected));
+    }
+
+    [Test]
+    public void AssertInvalid_WhenInvalid_DoesNotThrow()
+    {
+        // Arrange
+        ValidationState state = new();
+
+        state.AddError("Test Property", "Test Error");
+
+        Result result = Result.Invalid(state);
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => TestBase.TestAssertInvalid(result));
+    }
+
+    [Test]
+    public void AssertInvalid_WhenNotInvalid_DoesThrow()
+    {
+        // Arrange
+        ValidationState state = new();
+
+        state.AddError("Test Property", "Test Error");
+
+        Result result = Result.Success();
+
+        // Act & Assert
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertInvalid(result));
+    }
+
+    [Test]
+    public void AssertDomainError_WhenDomainError_DoesNotThrow()
+    {
+        // Arrange
+        const string message = "Test Error Message";
+
+        Result result = Result.DomainError(message);
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => TestBase.TestAssertDomainError(result, message));
+    }
+
+    [Test]
+    public void AssertDomainError_WhenDomainErrorAndMessagesDoNotMatch_DoesThrow()
+    {
+        // Arrange
+        const string expectedMessage = "Test Expected Message";
+
+        const string actualMessage = "Test Actual Message";
+
+        Result result = Result.DomainError(actualMessage);
+
+        // Act & Assert
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertDomainError(result, expectedMessage));
+    }
+
+    [Test]
+    public void AssertDomainError_WhenNotDomainError_DoesThrow()
+    {
+        // Arrange
+        const string message = "Test Error Message";
+
+        Result result = Result.Success();
+
+        // Act & Assert
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertDomainError(result, message));
+    }
+
+    [Test]
+    public void AssertConflict_WhenConflict_DoesNotThrow()
+    {
+        // Arrange
+        const string message = "Test Conflict Message";
+
+        Result result = Result.Conflict(message);
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => TestBase.TestAssertConflict(result, message));
+    }
+
+    [Test]
+    public void AssertConflict_WhenConflictAndMessagesDoNotMatch_DoesThrow()
+    {
+        // Arrange
+        const string expectedMessage = "Test Expected Message";
+
+        const string actualMessage = "Test Actual Message";
+
+        Result result = Result.Conflict(actualMessage);
+
+        // Act & Assert
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertConflict(result, expectedMessage));
+    }
+
+    [Test]
+    public void AssertCanceled_WhenCanceled_DoesNotThrow()
+    {
+        // Arrange
+        Result result = Result.Canceled();
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => TestBase.TestAssertCanceled(result));
+    }
+
+    [Test]
+    public void AssertCanceled_WhenNotCanceled_DoesThrow()
+    {
+        // Arrange
+        Result result = Result.Success();
+
+        // Act & Assert
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertCanceled(result));
+    }
+
+    [Test]
+    public void AssertNotFound_WhenNotFound_DoesNotThrow()
+    {
+        // Arrange
+        Result result = Result.NotFound();
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => TestBase.TestAssertNotFound(result));
+    }
+
+    [Test]
+    public void AssertNotFound_WhenNotNotFound_DoesNotThrow()
+    {
+        // Arrange
+        Result result = Result.Success();
+
+        // Act & Assert
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertNotFound(result));
+    }
+
+    [Test]
+    public void AssertInternalError_WhenInternalError_DoesNotThrow()
+    {
+        // Arrange
+        const string message = "Test Error Message";
+
+        Result result = Result.InternalError(message);
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => TestBase.TestAssertInternalError(result, message));
+    }
+
+    [Test]
+    public void AssertInternalError_WhenInternalErrorAndMessagesDoNotMatch_DoesThrow()
+    {
+        // Arrange
+        const string expectedMessage = "Test Expected Message";
+
+        const string actualMessage = "Test Actual Message";
+
+        Result result = Result.InternalError(actualMessage);
+
+        // Act & Assert
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertInternalError(result, expectedMessage));
+    }
+
+    [Test]
+    public void AssertInternalError_WhenNotInternalError_DoesThrow()
+    {
+        // Arrange
+        const string message = "Test Error Message";
+
+        Result result = Result.Success();
+
+        // Act & Assert
+        Assert.Throws<MultipleAssertException>(() => TestBase.TestAssertInternalError(result, message));
     }
 }


### PR DESCRIPTION
- Add `UsingPropertiesComparer()` to AssertSuccess method in TestBase

- Add tests for TestBase

- General testing improvements